### PR TITLE
Multiple Fixes to Header Component

### DIFF
--- a/projects/cut-lib/src/lib/header/header-app-switcher/header-app-switcher.component.html
+++ b/projects/cut-lib/src/lib/header/header-app-switcher/header-app-switcher.component.html
@@ -1,16 +1,11 @@
-<div class="wrapper-app-switcher" *ngIf="showAppSwitcher()">
-  <cut-drop-box dropStyle="fixed-down-left" [open]="open">
-    <cut-drop-box-anchor tabindex="0">
-      <!-- <span class="hidden-lg-up">{{headerObj.product.title}}</span> -->
-      <mat-icon class="app-switcher-icon">apps</mat-icon>
-    </cut-drop-box-anchor>
-    <cut-drop-box-content *ngIf="headerObj.appSwitcher">
-      <ul class="list-style-header-sub-nav">
-        <li *ngFor="let item of headerObj.appSwitcher" class="has-separator">
-          <a *ngIf="!item.hidden" [class.active]="item.isActive" title="{{item.altTxt}}"
-             (click)="emitActionType('SWITCH_APP_ACTION', item.title, item)" tabindex="0">{{item.title}}</a>
-        </li>
-      </ul>
-    </cut-drop-box-content>
-  </cut-drop-box>
+<div *ngIf="showAppSwitcher()">
+  <button mat-button class="cut-app-switcher-button" [matMenuTriggerFor]="menu">
+    <mat-icon class="app-switcher-icon">apps</mat-icon>
+  </button>
+  <mat-menu #menu="matMenu" class="cut-header-sub-nav">
+    <div mat-menu-item class="cut-menu-item" *ngFor="let item of headerObj.appSwitcher">
+      <a *ngIf="item.externalPath && !item.hidden" [class.active]="item.isActive" title="{{item.altTxt}}"
+        (click)="routeToExternalPath(item)" tabindex="0">{{item.title}}</a>
+    </div>
+  </mat-menu>
 </div>

--- a/projects/cut-lib/src/lib/header/header-app-switcher/header-app-switcher.component.scss
+++ b/projects/cut-lib/src/lib/header/header-app-switcher/header-app-switcher.component.scss
@@ -28,59 +28,10 @@ cut-drop-box-anchor {
   }
 }
 
-.wrapper-app-switcher {
-  margin-top: rem-calc(6);
+.cut-app-switcher-button {
+  padding: 0 0;
 }
 
-.list-style-header-sub-nav {
-  margin: 0px;
-  padding: 0px;
-  list-style-type: none;
-
-  >li {
-    a {
-      color: $color-link;
-      padding: $padding-base;
-      text-decoration: none;
-      display: block;
-      cursor: pointer;
-
-      &:hover {
-        background: $accent-beta-light;
-        color: $WHITE;
-      }
-
-      &:focus {
-        outline: 0;
-        background: $accent-beta-light;
-        color: $WHITE;
-      }
-
-      &:active,
-      &.active {
-        background: $accent-beta-darker;
-        color: $WHITE;
-      }
-    }
-
-    &:last-child {
-      border-radius: 0 0 $border-radius-base $border-radius-base;
-
-      a {
-        border-radius: 0 0 $border-radius-base $border-radius-base;
-      }
-    }
-
-    &.active {
-      background: $accent-beta-darker;
-
-      a {
-        color: $WHITE;
-      }
-    }
-
-    &.has-separator {
-      border-bottom: solid 1px $color-border;
-    }
-  }
+.mat-button {
+  min-width: rem-calc(15);
 }

--- a/projects/cut-lib/src/lib/header/header-app-switcher/header-app-switcher.component.spec.ts
+++ b/projects/cut-lib/src/lib/header/header-app-switcher/header-app-switcher.component.spec.ts
@@ -94,15 +94,6 @@ describe("HeaderAppSwitcherComponent", () => {
     expect(bentoImg).toBeTruthy();
   });
 
-  it("should call emitActionType", fakeAsync(inject([CutHeaderService], (serv: CutHeaderService) => {
-    {
-      spyOn(serv, "emitActionType");
-      component.emitActionType("");
-      tick(350);
-      expect(serv.emitActionType).toHaveBeenCalled();
-    }
-  })));
-
   it("should call routeToExternalPath", fakeAsync(inject([CutHeaderService], (serv: CutHeaderService) => {
     {
       spyOn(serv, "routeToExternalPath");

--- a/projects/cut-lib/src/lib/header/header-app-switcher/header-app-switcher.component.spec.ts
+++ b/projects/cut-lib/src/lib/header/header-app-switcher/header-app-switcher.component.spec.ts
@@ -1,6 +1,6 @@
 import { CommonModule } from "@angular/common";
 import { async, ComponentFixture, fakeAsync, inject, TestBed, tick } from "@angular/core/testing";
-import { MatIconModule } from "@angular/material";
+import { MatIconModule, MatMenuModule } from "@angular/material";
 import { RouterModule } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
 import { DropBoxModule } from "../../drop-box/drop-box.module";
@@ -13,7 +13,7 @@ describe("HeaderAppSwitcherComponent", () => {
 
   beforeEach(async(async () => {
     await TestBed.configureTestingModule({
-      imports: [CommonModule, DropBoxModule, RouterModule, RouterTestingModule, MatIconModule],
+      imports: [CommonModule, DropBoxModule, RouterModule, RouterTestingModule, MatIconModule, MatMenuModule],
       declarations: [CutHeaderAppSwitcherComponent],
       providers: [CutHeaderService]
     })

--- a/projects/cut-lib/src/lib/header/header-app-switcher/header-app-switcher.component.ts
+++ b/projects/cut-lib/src/lib/header/header-app-switcher/header-app-switcher.component.ts
@@ -9,7 +9,7 @@ import { CutHeaderService } from "../header.service";
 export class CutHeaderAppSwitcherComponent implements OnInit {
 
   headerObj: any;
-  open = {isOpen: false};
+  open = { isOpen: false };
 
   constructor(private headerService: CutHeaderService) {
   }
@@ -20,19 +20,8 @@ export class CutHeaderAppSwitcherComponent implements OnInit {
     });
   }
 
-  routeToExternalPath(path: string) {
-    this.headerService.routeToExternalPath(path);
-  }
-
-  emitActionType(action: string, element?: string, item?: any) {
-    let subItem;
-    if (!element) {
-      subItem = "";
-    } else {
-      subItem = ":" + element;
-    }
-    this.open.isOpen = false;
-    this.headerService.emitActionType(action, "appSwitcher" + subItem, item);
+  routeToExternalPath(item) {
+    this.headerService.routeToExternalPath(item);
   }
 
   showAppSwitcher() {

--- a/projects/cut-lib/src/lib/header/header-user-profile/header-user-profile.component.html
+++ b/projects/cut-lib/src/lib/header/header-user-profile/header-user-profile.component.html
@@ -6,20 +6,20 @@
   <mat-menu #menu="matMenu" class="cut-header-sub-nav">
     <!-- <ul class="list-style-header-sub-nav"> -->
     <div mat-menu-item class="cut-menu-item">
-      <h4>{{headerObj.userProfile.user.first_name}} {{headerObj.userProfile.user.last_name}}</h4>
-      <span class="ellipsis-truncate">{{headerObj.userProfile.user.email}}</span>
-      <span class="ellipsis-truncate">{{headerObj.userProfile.user.accountName}}</span>
+      <strong>{{headerObj.userProfile.user.first_name}} {{headerObj.userProfile.user.last_name}}</strong>
+      <span class="ellipsis-truncate m-t-10">{{headerObj.userProfile.user.email}}</span>
+      <span class="ellipsis-truncate">{{headerObj.userProfile.user.current_account_name}}</span>
     </div>
     <div mat-menu-item class="cut-menu-item" *ngFor="let item of headerObj.userProfile.options">
       <!-- <li [class.has-separator]="item.hasSeparator" *ngFor="let item of headerObj.userProfile.options"> -->
       <a *ngIf="item.internalPath && !item.hidden" [class.SignOut]="item.title === 'Sign Out'"
-         [routerLink]="[item.internalPath]" [class.active]="showAsActive(item)" title="{{item.altTxt}}"
-         tabindex="0">{{item.title}}</a>
+        [routerLink]="[item.internalPath]" [class.active]="showAsActive(item)" title="{{item.altTxt}}"
+        tabindex="0">{{item.title}}</a>
       <a *ngIf="item.externalPath && !item.hidden" [class.SignOut]="item.title === 'Sign Out'"
-         [href]="item.externalPath" [target]="getTargetAttribute(item.newWindow)" title="{{item.altTxt}}"
-         tabindex="0">{{item.title}}</a>
+        [href]="item.externalPath" [target]="getTargetAttribute(item.newWindow)" title="{{item.altTxt}}"
+        tabindex="0">{{item.title}}</a>
       <a *ngIf="item.action && !item.hidden && item.title !== 'Background'" [class.SignOut]="item.title === 'Sign Out'"
-         (click)="emitActionType(item.action, item.title)" title="{{item.altTxt}}" tabindex="0">{{item.title}}</a>
+        (click)="emitActionType(item.action, item.title)" title="{{item.altTxt}}" tabindex="0">{{item.title}}</a>
       <!-- <div class="themeSelector" *ngIf="item.title === 'Background'">
           <h5 class="titleText">Background Color</h5>
           <h5>Choose your background color from the options below.</h5>

--- a/projects/cut-lib/src/lib/header/header-user-profile/header-user-profile.component.scss
+++ b/projects/cut-lib/src/lib/header/header-user-profile/header-user-profile.component.scss
@@ -107,6 +107,7 @@ cut-drop-box /deep/ {
   &:first-child {
     padding: $padding-base;
     border-bottom: solid 1px $color-border;
+    line-height: rem-calc(13);
 
     h4 {
       margin-bottom: $padding-base/2;
@@ -115,6 +116,7 @@ cut-drop-box /deep/ {
     .ellipsis-truncate {
       color: $color-body;
       @extend %has-truncate;
+      margin-bottom: rem-calc(5);
     }
   }
 

--- a/projects/cut-lib/src/lib/header/header/header.component.html
+++ b/projects/cut-lib/src/lib/header/header/header.component.html
@@ -1,4 +1,5 @@
-<mat-toolbar [className]="!isFlattened ? 'cut-header mat-elevation-z6' : 'cut-header cut-header-flat'" [class.cut-header-fixed]="isFixed">
+<mat-toolbar [className]="!isFlattened ? 'cut-header mat-elevation-z6' : 'cut-header cut-header-flat'"
+  [class.cut-header-fixed]="isFixed">
   <!-- <section> -->
   <div class="cut-header-wrapper">
     <span class="trigger-menu fa fa-bars hidden-lg-up" *ngIf="validHeaderObj$ | async" tabindex="0"
@@ -26,12 +27,8 @@
       <cut-header-notifications *ngIf="headerObj.notifications"></cut-header-notifications>
     </div>
     <div class="cut-profile-main">
-      <!-- <span class="header-item hidden-md-down" *ngIf="!headerObj.newFeatures.hidden"
-        (click)="emitActionType('NEW_FEATURES_ACTION', 'newFeatures')" tabindex="0">New Features</span> -->
-      <span class="header-item hidden-md-down">
-        <cut-header-app-switcher></cut-header-app-switcher>
-      </span>
-        <cut-header-user-profile></cut-header-user-profile>
+      <cut-header-app-switcher></cut-header-app-switcher>
+      <cut-header-user-profile></cut-header-user-profile>
     </div>
   </div>
   <!-- <hr/>

--- a/src/app/examples/header/header.component.ts
+++ b/src/app/examples/header/header.component.ts
@@ -246,6 +246,7 @@ export class HeaderComponentExample implements OnInit {
 					"last_name": "Tester3",
 					"id": "U815D35WGQZS41Y2KJG",
 					"sub": "U815D35WGQZS41Y2KJG",
+					"current_account_name": "Demo Account",
 					"phone_number": "719-659-6885",
 					"status": "Active",
 					"user_type": "EmployerCompany",


### PR DESCRIPTION
- Use `mat-menu` for the header app switcher.
- Added `routeToExternalPath` to the app switcher items which would help to navigate to the external path.
- Show user email address and current account name in the profile dropdown.

![Screenshot 2019-08-23 at 6 26 41 PM](https://user-images.githubusercontent.com/17109020/63594733-e0658900-c5d4-11e9-94ee-20908a256500.png)
![Screenshot 2019-08-23 at 6 26 49 PM](https://user-images.githubusercontent.com/17109020/63594734-e0658900-c5d4-11e9-9972-c1a726cb4681.png)
